### PR TITLE
rbenv-gem-rehash deprecated

### DIFF
--- a/web-development.yml
+++ b/web-development.yml
@@ -33,7 +33,6 @@
       - peco
       - nvm
       - rbenv
-      - rbenv-gem-rehash
       - ruby-build
       - the_silver_searcher
       - vim


### PR DESCRIPTION
Never run rbenv rehash again. This rbenv plugin automatically runs rbenv rehash every time you install or uninstall a gem. https://github.com/rbenv/rbenv-gem-rehash

shocking :scream: 
